### PR TITLE
<gemini-cli>のコマンド実行時にシェルを使用しないよう修正

### DIFF
--- a/src/gemini.py
+++ b/src/gemini.py
@@ -48,7 +48,7 @@ def run_gemini(prompt: str, workdir: Optional[str | Path] = None) -> str:
             text=True,            # decode bytes → str
             cwd=str(cwd) if cwd is not None else None,
             check=False,           # manual error handling
-            shell=True,         # shell=True for shell injection protection
+            shell=False,
             encoding='utf-8',
         )
     except FileNotFoundError as exc:


### PR DESCRIPTION
お疲れ様です！
`src/gemini.py`におけるGemini CLIの呼び出し処理について、より安定した動作を目指すための修正を提案します。

### 変更内容

`subprocess.run` を呼び出す際の引数から `shell=True` ではなくデフォルトの `shell=False` を使用するように変更しました。

```python:src/gemini.py
# 修正前
completed = subprocess.run(
    CMD,
    capture_output=True,
    text=True,
    cwd=str(cwd) if cwd is not None else None,
    check=False,
    shell=True,  # ← この指定が問題でした
    encoding='utf-8',
)

# 修正後
completed = subprocess.run(
    CMD,
    capture_output=True,
    text=True,
    cwd=str(cwd) if cwd is not None else None,
    check=False,
    shell=False
    encoding='utf-8',
)
```

### 修正の背景と原因の推測

#### 発生した問題

私の開発環境（M2 Mac / zsh）でこのボットを動かした際、LINEでプロンプトを送信してもGemini CLIが正しく実行されず、LINEに実行結果が返ってこない問題が発生しました（実行エラー通知も届かず）

#### 原因の推測

`history`配下には、下記のように`<gemini-cli>`の指定があるログが出力されていたので、Gemini CLI実行時のエラーだと推測しています。
``` json
{"timestamp": "2025-07-01T19:52:05.995580+09:00", "role": "model", "content": "```\n<gemini-cli>\nローカルディレクトリに `index.html` というファイルを作成し、以下のHTMLコードを記述してください。\n\n```html\n<!DOCTYPE html>\n<html lang=\"ja\">\n<head>\n  <meta charset=\"UTF-8\">\n  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1.0\">\n  <title>シンプルなホームページ</title>\n</head>\n<body>\n  <h1>ようこそ！</h1>\n  <p>これは簡単なホームページの例です。</p>\n</body>\n</html>\n```\n\n作成後、ファイル名 `index.html` を返してください。\n</gemini-cli>\n```\n\n`index.html`ファイルを作成し、ファイル名`index.html`を返しました。\n\n\n"}
```

調査したところ、`subprocess.run`にコマンドを**リスト形式**で渡しつつ `shell=True` を指定していることが原因だと考えられます。

Pythonの仕様上、この組み合わせで実行すると、リストの2番目以降の要素（`-p`やプロンプトの文字列）が`gemini`コマンドへの引数ではなく、**シェル自体への引数**として解釈されてしまうようです。（[該当のPythonドキュメント](https://docs.python.org/ja/3.13/library/subprocess.html#frequently-used-arguments)）

私の`zsh`環境ではこの解釈がうまく機能せずコマンド実行が失敗していましたが、オーナーの環境で正常に動作していたのは、利用されているシェルがこの特殊な引数の渡し方を偶然にも許容する挙動だったためと推測されます。

### この修正によるメリット

`shell=False`に変更することで、中間シェルを挟まずにOSが直接`gemini`コマンドを実行するようになります。
これにより、

  * 引数が誤って解釈されることなく、`gemini`プログラムに正確に渡される
  * シェルの種類や設定といった環境の違いに左右されない、安定した動作が保証される

というメリットがあります。
これはPythonの公式ドキュメントでも推奨されている、より安全で確実な方法です。

お忙しいところ恐れ入りますが、ご確認のほどよろしくお願いいたします。